### PR TITLE
Fixes MemcachedSessionInterface to work with Python 3

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by Shipeng Feng.
     :license: BSD, see LICENSE for more details.
 """
+import sys
 import time
 from datetime import datetime
 from uuid import uuid4
@@ -173,14 +174,21 @@ class MemcachedSessionInterface(SessionInterface):
             timeout += int(time.time())
         return timeout
 
+    def _encode_key(self, key, encoding='utf-8'):
+        if sys.version_info.major == 2:
+            if isinstance(key, unicode):
+                return key.encode(encoding)
+        else:
+            if isinstance(key, bytes):
+                return key.decode(encoding)
+        return key
+
     def open_session(self, app, request):
         sid = request.cookies.get(app.session_cookie_name)
         if not sid:
             sid = self._generate_sid()
             return self.session_class(sid=sid)
-        full_session_key = self.key_prefix + sid
-        if isinstance(full_session_key, unicode):
-            full_session_key = full_session_key.encode('utf-8')
+        full_session_key = self._encode_key(self.key_prefix + sid)
         val = self.client.get(full_session_key)
         if val is not None:
             try:
@@ -193,9 +201,7 @@ class MemcachedSessionInterface(SessionInterface):
     def save_session(self, app, session, response):
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
-        full_session_key = self.key_prefix + session.sid
-        if isinstance(full_session_key, unicode):
-            full_session_key = full_session_key.encode('utf-8')
+        full_session_key = self._encode_key(self.key_prefix + session.sid)
         if not session:
             if session.modified:
                 self.client.delete(full_session_key)


### PR DESCRIPTION
MemcachedSessionInterface checks if the key is unicode, and if so it encodes it to a string. 

In python 3 there is no longer a unicode class, but instead the bytes class. This update checks the version of python and if it's 2, it behaves as it did before, if it's 3, it checks to see if the key is a bytes object, and if so decodes it to a string object.

I ran test_session.py in both python 2 and python 3 and the tests passed.
