### PR TITLE
Fix init & multiple app issues with SQLAlchemy interface

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -439,23 +439,27 @@ class SqlAlchemySessionInterface(SessionInterface):
         self.key_prefix = key_prefix
         self.use_signer = use_signer
 
-        class Session(self.db.Model):
-            __tablename__ = table
+        if table not in self.db.metadata:
 
-            id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
-            data = self.db.Column(self.db.Text)
-            expiry = self.db.Column(self.db.DateTime)
+            class Session(self.db.Model):
+                __tablename__ = table
 
-            def __init__(self, session_id, data, expiry):
-                self.session_id = session_id
-                self.data = data
-                self.expiry = expiry
+                id = self.db.Column(self.db.Integer, primary_key=True)
+                session_id = self.db.Column(self.db.String(256), unique=True)
+                data = self.db.Column(self.db.Text)
+                expiry = self.db.Column(self.db.DateTime)
 
-            def __repr__(self):
-                return '<Session data %s>' % self.data
+                def __init__(self, session_id, data, expiry):
+                    self.session_id = session_id
+                    self.data = data
+                    self.expiry = expiry
 
-        self.sql_session_model = Session
+                def __repr__(self):
+                    return '<Session data %s>' % self.data
+
+            self.sql_session_model = db.session_ext_session_model = Session
+        else:
+            self.sql_session_model = db.session_ext_session_model
 
     def open_session(self, app, request):
         sid = request.cookies.get(app.session_cookie_name)

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -455,7 +455,6 @@ class SqlAlchemySessionInterface(SessionInterface):
             def __repr__(self):
                 return '<Session data %s>' % self.data
 
-        self.db.create_all()
         self.sql_session_model = Session
 
     def open_session(self, app, request):


### PR DESCRIPTION
These are some proposed fixes to issues I have run into with integrating Flask-Session into our application.  The two problems were:

1) the call to db.create_all() was causing problems as described here: https://github.com/fengsp/flask-session/issues/11
2) When instantiating an application multiple times in the same process (in our case, during testing) the method used to create the SA table/model would fail b/c it already existed.  But a check in for this so it's only created once for each DB.
