### PR TITLE
Varchar prefix may cause problems when using MySQL with unicode.

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -443,7 +443,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             __tablename__ = table
 
             id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
+            session_id = self.db.Column(self.db.String(255), unique=True)
             data = self.db.Column(self.db.Text)
             expiry = self.db.Column(self.db.DateTime)
 


### PR DESCRIPTION
The character limit depends on the character set. For example if you use `latin1`  then the largest column you can index is `varchar(767)`, but if you use `utf8` then the limit is `varchar(255)`.     

In `sessions.py`,  the attribute `session_id` of class `SqlAlchemySessionInterface` is set to `256`, however, when my database collection is set to `utf8`, it may cause a problen like this:

```
 1071, 'Specified key was too long; max key length is 767 bytes'  
```

And I change it to `255`, the problem is solved.
