### PR TITLE
Added support for signer alternatives

### DIFF
--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -64,6 +64,7 @@ class Session(object):
         config = app.config.copy()
         config.setdefault('SESSION_TYPE', 'null')
         config.setdefault('SESSION_USE_SIGNER', False)
+        config.setdefault('SESSION_SIGNER_TYPE', 'hmac_sha1')
         config.setdefault('SESSION_KEY_PREFIX', 'session:')
         config.setdefault('SESSION_REDIS', None)
         config.setdefault('SESSION_MEMCACHED', None)
@@ -80,7 +81,7 @@ class Session(object):
         if config['SESSION_TYPE'] == 'redis':
             session_interface = RedisSessionInterface(
                 config['SESSION_REDIS'], config['SESSION_KEY_PREFIX'],
-                config['SESSION_USE_SIGNER'])
+                config['SESSION_USE_SIGNER'], config['SESSION_SIGNER_TYPE'])
         elif config['SESSION_TYPE'] == 'memcached':
             session_interface = MemcachedSessionInterface(
                 config['SESSION_MEMCACHED'], config['SESSION_KEY_PREFIX'],
@@ -89,17 +90,19 @@ class Session(object):
             session_interface = FileSystemSessionInterface(
                 config['SESSION_FILE_DIR'], config['SESSION_FILE_THRESHOLD'],
                 config['SESSION_FILE_MODE'], config['SESSION_KEY_PREFIX'],
-                config['SESSION_USE_SIGNER'])
+                config['SESSION_USE_SIGNER'], config['SESSION_SIGNER_TYPE'])
         elif config['SESSION_TYPE'] == 'mongodb':
             session_interface = MongoDBSessionInterface(
                 config['SESSION_MONGODB'], config['SESSION_MONGODB_DB'],
                 config['SESSION_MONGODB_COLLECT'],
-                config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'])
+                config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'],
+                config['SESSION_SIGNER_TYPE'])
         elif config['SESSION_TYPE'] == 'sqlalchemy':
             session_interface = SqlAlchemySessionInterface(
                 app, config['SESSION_SQLALCHEMY'],
                 config['SESSION_SQLALCHEMY_TABLE'],
-                config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'])
+                config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'],
+                config['SESSION_SIGNER_TYPE'])
         else:
             session_interface = NullSessionInterface()
 


### PR DESCRIPTION
We are interested in using `flask-session` as our session system but noticed a lack of support for a SHA256 HMAC. In the past, I have been informed that this is stronger than the current default of a SHA1 HMAC (mostly due to length -- SHA1 is 160 bits, SHA256 is 256 bits).

https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Security

This PR adds backwards compatible support to opt in to using a SHA256 HMAC. In this PR:
- Added test to verify HMAC exists in SHA1 variant
- Added test for verifying SHA256 HMAC provides a longer HMAC
- Added collection of various signers
- Added `signer_type` option to all Session classes
