### PR TITLE
Fixsqlalchemy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git@github.com:mitsuhiko/flask-sphinx-themes.git
+	url = http://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -487,7 +487,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             def __repr__(self):
                 return '<Session data %s>' % self.data
 
-        self.db.create_all()
+        #self.db.create_all()
         self.sql_session_model = Session
 
     def open_session(self, app, request):

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -475,7 +475,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             __tablename__ = table
 
             id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
+            session_id = self.db.Column(self.db.Text, unique=True)
             data = self.db.Column(self.db.Text)
             expiry = self.db.Column(self.db.DateTime)
 


### PR DESCRIPTION
It seems like flask session key is now longer than the default 256 session type.

Also:
- I've switched the url scheme for submodules to be http that way you can put this module inside of "requirements.txt" and have it work on hosted environments such as heroku.
- Also, allow the user to create the tables with migrations instead of calling "create_all()" as that should be up to the user.
