### PR TITLE
Unique key length bug-fix for SQLAlchemy + unicode

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -475,7 +475,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             __tablename__ = table
 
             id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
+            session_id = self.db.Column(self.db.String(255), unique=True)
             data = self.db.Column(self.db.Text)
             expiry = self.db.Column(self.db.DateTime)
 


### PR DESCRIPTION
When using SQLAlchemy and Unicode fields having unique length of 256 we get
a unique index length of 256 \* 3 = 768 bytes, and 767 are allowed!
This causes an error:
"sqlalchemy.exc.ProgrammingError: (mysql.connector.errors.ProgrammingError) 1071
(42000): Specified key was too long; max key length is 767 bytes"

While the length of the 255 is quite enough to store uuid4 - hashes.
