### PR TITLE
Pickle protocol fix 

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -160,7 +160,7 @@ class RedisSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
-        val = self.serializer.dumps(dict(session))
+        val = self.serializer.dumps(dict(session), 0)
         self.redis.setex(name=self.key_prefix + session.sid, value=val,
                          time=total_seconds(app.permanent_session_lifetime))
         if self.use_signer:
@@ -273,10 +273,7 @@ class MemcachedSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
-        if not PY2:
-            val = self.serializer.dumps(dict(session), 0)
-        else:
-            val = self.serializer.dumps(dict(session))
+        val = self.serializer.dumps(dict(session), 0)
         self.client.set(full_session_key, val, self._get_memcache_timeout(
                         total_seconds(app.permanent_session_lifetime)))
         if self.use_signer:
@@ -431,7 +428,7 @@ class MongoDBSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
-        val = self.serializer.dumps(dict(session))
+        val = self.serializer.dumps(dict(session), 0)
         self.store.update({'id': store_id},
                           {'id': store_id,
                            'val': val,
@@ -540,7 +537,7 @@ class SqlAlchemySessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
-        val = self.serializer.dumps(dict(session))
+        val = self.serializer.dumps(dict(session), 0)
         if saved_session:
             saved_session.data = val
             saved_session.expiry = expires

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -475,7 +475,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             __tablename__ = table
 
             id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
+            session_id = self.db.Column(self.db.String(255), unique=True)
             data = self.db.Column(self.db.Text)
             expiry = self.db.Column(self.db.DateTime)
 


### PR DESCRIPTION
Error when using Python 3 + Unicode.
Only pickle protocol version 0 and 1 can accurately convert the data to
a string, because the storage we use the "Text" type field. I was the 
reason that the data is simply not saved to the database, without any errors.
In Python 3 pickle.dumps function protocol version installed by default 3. 
Therefore calls pickle.dumps() to explicitly specify the protocol version 0.
This was done.
