### PR TITLE
Adds check to ensure saved_session.expiry exists before utcnow()

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -513,7 +513,7 @@ class SqlAlchemySessionInterface(SessionInterface):
         store_id = self.key_prefix + sid
         saved_session = self.sql_session_model.query.filter_by(
             session_id=store_id).first()
-        if saved_session and saved_session.expiry <= datetime.utcnow():
+        if saved_session and (not saved_session.expiry or saved_session.expiry <= datetime.utcnow()):
             # Delete expired session
             self.db.session.delete(saved_session)
             self.db.session.commit()


### PR DESCRIPTION
Fixes issue #56 for SQLAlchemy. May be valuable for others.