### PR TITLE
Prevent sid reuse on redis miss

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -136,6 +136,7 @@ class RedisSessionInterface(SessionInterface):
                 return self.session_class(data, sid=sid)
             except:
                 return self.session_class(sid=sid, permanent=self.permanent)
+        sid = self._generate_sid()
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):


### PR DESCRIPTION
If there is not an active session associated with the sid of the request, don't reuse the same sid when creating a new session.