### PR TITLE
Fixed error that can occur if document.get('expiration') returns None

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -408,7 +408,7 @@ class MongoDBSessionInterface(SessionInterface):
 
         store_id = self.key_prefix + sid
         document = self.store.find_one({'id': store_id})
-        if document and document.get('expiration') <= datetime.utcnow():
+        if document and ((not document.get('expiration')) or document.get('expiration') <= datetime.utcnow()):
             # Delete expired session
             self.store.remove({'id': store_id})
             document = None


### PR DESCRIPTION
Not sure how my session got into this state but this change allows for a graceful recovery instead of an exception.