### PR TITLE
Added SESSION_SQLALCHEMY_SEQUENCE config to allow support for oracle …

### DIFF
--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -77,6 +77,7 @@ class Session(object):
         config.setdefault('SESSION_MONGODB_COLLECT', 'sessions')
         config.setdefault('SESSION_SQLALCHEMY', None)
         config.setdefault('SESSION_SQLALCHEMY_TABLE', 'sessions')
+        config.setdefault('SESSION_SQLALCHEMY_SEQUENCE', None)
 
         if config['SESSION_TYPE'] == 'redis':
             session_interface = RedisSessionInterface(
@@ -102,7 +103,7 @@ class Session(object):
                 app, config['SESSION_SQLALCHEMY'],
                 config['SESSION_SQLALCHEMY_TABLE'],
                 config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'],
-                config['SESSION_PERMANENT'])
+                config['SESSION_PERMANENT'], config['SESSION_SQLALCHEMY_SEQUENCE'])
         else:
             session_interface = NullSessionInterface()
 

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -466,7 +466,7 @@ class SqlAlchemySessionInterface(SessionInterface):
     session_class = SqlAlchemySession
 
     def __init__(self, app, db, table, key_prefix, use_signer=False,
-                 permanent=True):
+                 permanent=True, sequence=None):
         if db is None:
             from flask_sqlalchemy import SQLAlchemy
             db = SQLAlchemy(app)
@@ -474,11 +474,18 @@ class SqlAlchemySessionInterface(SessionInterface):
         self.key_prefix = key_prefix
         self.use_signer = use_signer
         self.permanent = permanent
+        self.sequence = sequence
 
         class Session(self.db.Model):
             __tablename__ = table
 
-            id = self.db.Column(self.db.Integer, primary_key=True)
+            if sequence:
+                id = self.db.Column(self.db.Integer,
+                                    self.db.Sequence(sequence),
+                                    primary_key=True)
+            else:
+                id = self.db.Column(self.db.Integer, primary_key=True)
+                
             session_id = self.db.Column(self.db.String(255), unique=True)
             data = self.db.Column(self.db.LargeBinary)
             expiry = self.db.Column(self.db.DateTime)


### PR DESCRIPTION
Added new config item to support specifying the sequence the id primary key, a requirment if using an oracle database with sqlalchemy

See auto-increment behavior for oracle below
https://docs.sqlalchemy.org/en/13/dialects/oracle.html#auto-increment-behavior