### PR TITLE
Autodelete sessions in SqlAlchemySessionInterface

### DIFF
--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -65,6 +65,7 @@ class Session(object):
         config.setdefault('SESSION_TYPE', 'null')
         config.setdefault('SESSION_PERMANENT', True)
         config.setdefault('SESSION_USE_SIGNER', False)
+        config.setdefault('SESSION_AUTODELETE', False)
         config.setdefault('SESSION_KEY_PREFIX', 'session:')
         config.setdefault('SESSION_REDIS', None)
         config.setdefault('SESSION_MEMCACHED', None)
@@ -102,7 +103,8 @@ class Session(object):
                 app, config['SESSION_SQLALCHEMY'],
                 config['SESSION_SQLALCHEMY_TABLE'],
                 config['SESSION_KEY_PREFIX'], config['SESSION_USE_SIGNER'],
-                config['SESSION_PERMANENT'])
+                config['SESSION_PERMANENT'],
+                config['SESSION_AUTODELETE'])
         else:
             session_interface = NullSessionInterface()
 


### PR DESCRIPTION
The expired sessions are not deleted from the database in every case, so
the autodeletion of expired sessions has been implemented.

Deletion of the expired sessions (e.g. with a cronjob) would be feasible
in the application, but it is nicer to implement it directly in
flask-session.

The autodeletion be enabled by the `SESSION_AUTODELETE` config variable,
which defaults to `False`.

Major drawback: it slows down `open_session`.