### PR TITLE
Make Session table reusable

### DIFF
--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -486,6 +486,7 @@ class SqlAlchemySessionInterface(SessionInterface):
 
         class Session(self.db.Model):
             __tablename__ = table
+            __table_args__ = {'keep_existing': True}
 
             id = self.db.Column(self.db.Integer, primary_key=True)
             session_id = self.db.Column(self.db.String(255), unique=True)
@@ -500,7 +501,6 @@ class SqlAlchemySessionInterface(SessionInterface):
             def __repr__(self):
                 return '<Session data %s>' % self.data
 
-        # self.db.create_all()
         self.sql_session_model = Session
 
     def open_session(self, app, request):


### PR DESCRIPTION
Closes #175

If someone runs multiple tests and each test initializes a new instance of flask app (and thus a new initialization of flask_session happens), it results in the following error:
```
sqlalchemy.exc.InvalidRequestError: Table 'sessions' is already defined for this MetaData instance.  Specify 'extend_existing=True' to redefine options and columns on an existing Table object.
```

This is because typically the sqlalchemy db object is global and thus it's metadata is kept between tests runs. Which means that if someone executes `class SomeTable(db.Model)` twice, it breaks because the table is already stored in the metadata.

This PR solves this problem by setting `keep_existing`to `True`, which means that if sessions table is already in the metadata, it will be reused instead of trying to create a new one.

A test was also added for the mentioned change.