### PR TITLE
Assert that passed redis is of Type Redis Instance

### DIFF
--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -93,6 +93,12 @@ class RedisSessionInterface(SessionInterface):
     session_class = RedisSession
 
     def __init__(self, redis, key_prefix, use_signer=False, permanent=True):
+        from redis.client import Redis as RedisInstanceType
+        if not isintance(redis, RedisInstanceType):
+            raise TypeError(
+                f"Unexpected type {type(redis)} for redis Instance. "
+                "Please create a redis instance and set it to SESSION_REDIS."
+            )
         if redis is None:
             from redis import Redis
             redis = Redis()


### PR DESCRIPTION
We got stuck with the error that we set the redis connection string so SESSION_REDIS, with results in setting self.redis correctly, but then getting the error that str does not have method get. This asserts type safety and is more verbose.

Another way would be that you could check if it is of type string and then create a Redis Instance from there.