### PR TITLE
Fix Issue #191: Ensure session_id is Passed as String to response.set_cookie with Werkzeug 3.0.0

### DIFF
--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -159,6 +159,7 @@ class RedisSessionInterface(SessionInterface):
                          time=total_seconds(app.permanent_session_lifetime))
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id.decode()
         else:
             session_id = session.sid
         response.set_cookie(app.config["SESSION_COOKIE_NAME"], session_id,
@@ -281,6 +282,7 @@ class MemcachedSessionInterface(SessionInterface):
                         total_seconds(app.permanent_session_lifetime)))
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id.decode()
         else:
             session_id = session.sid
         response.set_cookie(app.config["SESSION_COOKIE_NAME"], session_id,
@@ -357,6 +359,7 @@ class FileSystemSessionInterface(SessionInterface):
                        total_seconds(app.permanent_session_lifetime))
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id.decode()
         else:
             session_id = session.sid
         response.set_cookie(app.config["SESSION_COOKIE_NAME"], session_id,
@@ -449,6 +452,7 @@ class MongoDBSessionInterface(SessionInterface):
                            'expiration': expires}, True)
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id.decode()
         else:
             session_id = session.sid
         response.set_cookie(app.config["SESSION_COOKIE_NAME"], session_id,
@@ -568,6 +572,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             self.db.session.commit()
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
+            session_id.decode()
         else:
             session_id = session.sid
         response.set_cookie(app.config["SESSION_COOKIE_NAME"], session_id,


### PR DESCRIPTION
Fixes #191. With the update to Werkzeug 3.0.0, response.set_cookie now requires a string for value rather than a bytes object or string. Added decoding of the signed session id to restore compatibility.

