### PR TITLE
check expiry is not none

### DIFF
--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -522,11 +522,12 @@ class SqlAlchemySessionInterface(SessionInterface):
         store_id = self.key_prefix + sid
         saved_session = self.sql_session_model.query.filter_by(
             session_id=store_id).first()
-        if saved_session and saved_session.expiry <= datetime.utcnow():
-            # Delete expired session
-            self.db.session.delete(saved_session)
-            self.db.session.commit()
-            saved_session = None
+        if saved_session.expiry is not None:
+            if saved_session and saved_session.expiry <= datetime.utcnow():
+                # Delete expired session
+                self.db.session.delete(saved_session)
+                self.db.session.commit()
+                saved_session = None
         if saved_session:
             try:
                 val = saved_session.data


### PR DESCRIPTION
Hi! I found this issue while working with the library
```
    if saved_session and saved_session.expiry <= datetime.utcnow():
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'NoneType' and 'datetime.datetime'
```