### PR TITLE
Generate session identifiers with secrets module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version ?
+---------
+
+Unreleased
+
+-   Use `secrets` module to generate session identifiers, with 128 bits of
+    entropy (was previously 122).
+
 Version 0.5.0
 -------------
 

--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -1,7 +1,7 @@
 import sys
 import time
 from datetime import datetime
-from uuid import uuid4
+import secrets
 try:
     import cPickle as pickle
 except ImportError:
@@ -60,7 +60,7 @@ class SqlAlchemySession(ServerSideSession):
 class SessionInterface(FlaskSessionInterface):
 
     def _generate_sid(self):
-        return str(uuid4())
+        return secrets.token_urlsafe(128//8)
 
     def _get_signer(self, app):
         if not app.secret_key:


### PR DESCRIPTION
And increase identifier entropy to 128 bits, as recommended by OWASP: https://owasp.org/www-community/vulnerabilities/Insufficient_Session-ID_Length