### PR TITLE
Update sessions.py to change the deprecated update call for session storage (MongoDB)

### DIFF
--- a/src/flask_session/sessions.py
+++ b/src/flask_session/sessions.py
@@ -443,10 +443,10 @@ class MongoDBSessionInterface(SessionInterface):
             conditional_cookie_kwargs["samesite"] = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         val = self.serializer.dumps(dict(session))
-        self.store.update({'id': store_id},
+        self.store.update_one({'id': store_id},{'$set':
                           {'id': store_id,
                            'val': val,
-                           'expiration': expires}, True)
+                           'expiration': expires}}, True)
         if self.use_signer:
             session_id = self._get_signer(app).sign(want_bytes(session.sid))
         else:


### PR DESCRIPTION
the update method was deprecated in flask pymongo but when trying to save session with mongodb and flask_pymongo the update method is called. This change makes the update to update_one along with a set call