### PR TITLE
Fix type annotation in Python < 3.8

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,6 +1,5 @@
 from flask import Flask, session
 from flask_session import Session
-from redis.exceptions import RedisError
 
 app = Flask(__name__)
 app.config.from_object(__name__)

--- a/src/flask_session/base.py
+++ b/src/flask_session/base.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import random
 from datetime import timedelta as TimeDelta
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import msgspec
 from flask import Flask, Request, Response
@@ -53,7 +53,7 @@ class ServerSideSession(CallbackDict, SessionMixin):
 
     def __init__(
         self,
-        initial: Optional[dict[str, Any]] = None,
+        initial: Optional[Dict[str, Any]] = None,
         sid: Optional[str] = None,
         permanent: Optional[bool] = None,
     ):


### PR DESCRIPTION
During tests in Apache Airflow integration with 0.7.0rc2 (https://github.com/apache/airflow/issues/36897) I've got an error 

```python
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/opt/airflow/airflow/__main__.py", line 57, in main
    args.func(args)
  File "/opt/airflow/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
  File "/opt/airflow/airflow/cli/commands/db_command.py", line 63, in resetdb
    db.resetdb(skip_init=args.skip_init)
  File "/opt/airflow/airflow/utils/session.py", line 79, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow/utils/db.py", line 1656, in resetdb
    drop_airflow_models(connection)
  File "/opt/airflow/airflow/utils/db.py", line 1728, in drop_airflow_models
    db = _get_flask_db(connection.engine.url)
  File "/opt/airflow/airflow/utils/db.py", line 714, in _get_flask_db
    from airflow.www.session import AirflowDatabaseSessionInterface
  File "/opt/airflow/airflow/www/session.py", line 23, in <module>
    from flask_session.sqlalchemy import SqlAlchemySessionInterface
  File "/usr/local/lib/python3.8/site-packages/flask_session/sqlalchemy/__init__.py", line 1, in <module>
    from .sqlalchemy import SqlAlchemySession, SqlAlchemySessionInterface  # noqa: F401
  File "/usr/local/lib/python3.8/site-packages/flask_session/sqlalchemy/sqlalchemy.py", line 12, in <module>
    from ..base import ServerSideSession, ServerSideSessionInterface
  File "/usr/local/lib/python3.8/site-packages/flask_session/base.py", line 26, in <module>
    class ServerSideSession(CallbackDict, SessionMixin):
  File "/usr/local/lib/python3.8/site-packages/flask_session/base.py", line 56, in ServerSideSession
    initial: Optional[dict[str, Any]] = None,
TypeError: 'type' object is not subscriptable
```

`dict[str, Any]` available only Python 3.9+, it could be enabled in lower version by add in top of the imports

```python
from __future__ import annotations
```

However since in flask-session do not use future annotations (https://docs.python.org/3/library/__future__.html#module-contents) I just use Dict from typing instead