### PR TITLE
Remove rogue comma in cachelib example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,6 +84,6 @@ The following example demonstrates how to use CacheLib as a session backend with
 
     SESSION_TYPE = 'cachelib'
     SESSION_SERIALIZATION_FORMAT = 'json'
-    SESSION_CACHELIB = FileSystemCache(threshold=500, cache_dir="/sessions"),
+    SESSION_CACHELIB = FileSystemCache(threshold=500, cache_dir="/sessions")
     app.config.from_object(__name__)
     Session(app)


### PR DESCRIPTION
There was a rogue comma in the cachelib example which left me utterly confused when everything broke :)