### PR TITLE
Provide proper configuration value for dynamodb table name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -220,7 +220,7 @@ Dynamodb
       
       Default: Instance connected to ``'localhost:8000'``
 
-.. py:data:: SESSION_DYNAMODB_TABLE_NAME
+.. py:data:: SESSION_DYNAMODB_TABLE
 
       The name of the table you want to use.
       


### PR DESCRIPTION
The correct value to override is "SESSION_DYNAMODB_TABLE", not "SESSION_DYNAMODB_TABLE_NAME": https://github.com/pallets-eco/flask-session/blob/bc2fe67958bff5e46023c4807b5e75ca350554eb/src/flask_session/defaults.py#L45