### PR TITLE
Use get_cookie_name to get cookie name in open_session

### DIFF
--- a/src/flask_session/base.py
+++ b/src/flask_session/base.py
@@ -331,7 +331,7 @@ class ServerSideSessionInterface(FlaskSessionInterface, ABC):
 
     def open_session(self, app: Flask, request: Request) -> ServerSideSession:
         # Get the session ID from the cookie
-        sid = request.cookies.get(app.config["SESSION_COOKIE_NAME"])
+        sid = request.cookies.get(self.get_cookie_name(app))
 
         # If there's no session ID, generate a new one
         if not sid:


### PR DESCRIPTION
Sometimes, we might need to override the `get_cookie_name` to get the cookie name from other places instead of `app.config["SESSION_COOKIE_NAME"]`.